### PR TITLE
fix: Next.js 15 페이지 컴포넌트에서 params await (pages-params)

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -41,8 +41,9 @@ async function getPost(slug: string) {
   }
 }
 
-export default async function PostPage({ params }: { params: { slug: string } }) {
-  const post = await getPost(params.slug);
+export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const resolvedParams = await params;
+  const post = await getPost(resolvedParams.slug);
 
   if (!post) {
     notFound();

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -41,8 +41,9 @@ async function getProject(slug: string) {
   }
 }
 
-export default async function ProjectPage({ params }: { params: { slug: string } }) {
-  const project = await getProject(params.slug);
+export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
+  const resolvedParams = await params;
+  const project = await getProject(resolvedParams.slug);
 
   if (!project) {
     notFound();


### PR DESCRIPTION
## 설명

Next.js 15 버전에서 페이지 컴포넌트에 `params`가 `Promise` 형태로 전달되도록 변경됨에 따라 발생하는 타입 오류를 수정했습니다.

### 변경 내용

- `app/posts/[slug]/page.tsx` 파일에서 `PostPage` 컴포넌트의 `params`를 `Promise<{ slug: string }>` 타입으로 변경하고, `await params`를 통해 실제 `slug` 값을 가져오도록 수정했습니다.
- `app/projects/[slug]/page.tsx` 파일에서 `ProjectPage` 컴포넌트의 `params`를 `Promise<{ slug: string }>` 타입으로 변경하고, `await params`를 통해 실제 `slug` 값을 가져오도록 수정했습니다.

### 변경 동기

Next.js 15 업그레이드 이후 `params` 처리 방식 변경으로 인해 발생한 타입 오류를 해결하고, 페이지 컴포넌트에서 동적 라우팅 파라미터를 올바르게 처리하여 안정적인 데이터 페칭을 보장합니다.

해결된 이슈 # (이슈 번호) - *관련 이슈가 있다면 여기에 추가해주세요.*

## 변경 유형

- [x] 버그 수정 (이슈를 해결하는 비호환적 변경)
- [ ] 새로운 기능 (기능을 추가하는 비호환적 변경)
- [ ] 호환성 파괴 변경 (기존 기능이 예상대로 작동하지 않게 하는 수정 또는 기능)
- [ ] 이 변경은 문서 업데이트가 필요합니다.

## 테스트 방법

변경 사항을 확인하기 위해 다음 테스트를 수행했습니다.

- 로컬 환경에서 애플리케이션을 실행하고 `/posts/[slug]` 및 `/projects/[slug]` 경로의 페이지로 이동하여 페이지가 타입 오류 없이 올바르게 로드되는지 확인했습니다.
