### PR TITLE
develop → main: MDX 헤더 모바일 반응형, 네컷 사진 모바일 대응

### DIFF
--- a/_posts/20260401-ttalkkakthon-organizer-retrospective.mdx
+++ b/_posts/20260401-ttalkkakthon-organizer-retrospective.mdx
@@ -117,8 +117,8 @@ AI 심사는 시간이 걸리다 보니 본선 발표와 동시에 진행할 수
 - [암쏘쏘리 GitHub](https://github.com/ttalkkak-and-pray/im-so-sorry-but-i-love-you) / [배포](https://im-so-sorry.kro.kr/)
 
 <div className="flex justify-center items-start gap-4">
-  <img src="/images/posts/ttalkkakthon-organizer-retrospective/004.webp" alt="나만의 4컷 기기" className="h-80 w-auto rounded-lg" />
-  <img src="/images/posts/ttalkkakthon-organizer-retrospective/005.webp" alt="나만의 4컷 결과물" className="h-80 w-auto rounded-lg" />
+  <img src="/images/posts/ttalkkakthon-organizer-retrospective/004.webp" alt="나만의 4컷 기기" className="h-48 md:h-80 w-auto rounded-lg" />
+  <img src="/images/posts/ttalkkakthon-organizer-retrospective/005.webp" alt="나만의 4컷 결과물" className="h-48 md:h-80 w-auto rounded-lg" />
 </div>
 
 뒷풀이에서 참가자들이 이번이 몇 회차 해커톤이냐고 물어볼 정도로 진행이 매끄러웠다. 1회차라고 하니 놀라는 반응이었다.

--- a/lib/mdx-components.ts
+++ b/lib/mdx-components.ts
@@ -7,22 +7,22 @@ export const mdxComponents: MDXComponents = {
   h1: (props) =>
     createElement("h1", {
       ...props,
-      className: "text-4xl font-bold mt-10 mb-5 text-foreground",
+      className: "text-2xl md:text-4xl font-bold mt-10 mb-5 text-foreground",
     }),
   h2: (props) =>
     createElement("h2", {
       ...props,
-      className: "text-3xl font-semibold mt-9 mb-4 text-foreground border-b border-border pb-2",
+      className: "text-xl md:text-3xl font-semibold mt-9 mb-4 text-foreground border-b border-border pb-2",
     }),
   h3: (props) =>
     createElement("h3", {
       ...props,
-      className: "text-2xl font-semibold mt-8 mb-3 text-foreground",
+      className: "text-lg md:text-2xl font-semibold mt-8 mb-3 text-foreground",
     }),
   h4: (props) =>
     createElement("h4", {
       ...props,
-      className: "text-xl font-semibold mt-6 mb-3 text-foreground",
+      className: "text-base md:text-xl font-semibold mt-6 mb-3 text-foreground",
     }),
   p: (props) =>
     createElement("p", {


### PR DESCRIPTION
## Summary

- MDX 헤더(h1~h4) 모바일 반응형 글자 크기 적용
- 딸깍톤 포스트 나만의 4컷 사진 모바일 높이 축소

## Changes

### 스타일
- h1~h4 모바일에서 한 단계씩 축소
- 나만의 4컷 이미지 h-48 md:h-80 반응형

## Test plan

- [x] `pnpm build` 성공