### PR TITLE
feature/design-consistency → develop: 디자인 일관성·가독성 보완

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,14 +1,12 @@
 import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 
 const interests = ["풀스택 개발", "UX 최적화", "클린 아키텍처", "기술 리더십", "스마트 제조", "안드로이드 개발"];
 
 const AboutPage = () => {
   return (
     <PageContainer>
-      <header className="mb-10">
-        <h1 className="text-xl font-semibold text-foreground tracking-tight">About</h1>
-        <p className="text-sm text-muted-foreground mt-1">언어로 세상을 표현하는 개발자</p>
-      </header>
+      <PageHeader title="About" description="언어로 세상을 표현하는 개발자" />
 
       <div className="space-y-0">
         {/* 자기소개 */}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 
 const contactLinks = [
   {
@@ -25,12 +26,7 @@ const contactLinks = [
 const ContactPage = () => {
   return (
     <PageContainer>
-      <header className="mb-10">
-        <h1 className="text-xl font-semibold text-foreground tracking-tight">Contact</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          프로젝트 협업, 채용 문의, 기술적인 질문 등 편하게 연락주세요
-        </p>
-      </header>
+      <PageHeader title="Contact" description="프로젝트 협업, 채용 문의, 기술적인 질문 등 편하게 연락주세요" />
 
       <div className="space-y-3">
         {contactLinks.map((link) => (

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,4 +1,5 @@
 import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -52,10 +53,7 @@ const timeline: TimelineItem[] = [
 const EducationPage = () => {
   return (
     <PageContainer>
-      <header className="mb-10">
-        <h1 className="text-xl font-semibold text-foreground tracking-tight">Education & Experience</h1>
-        <p className="text-sm text-muted-foreground mt-1">학력 및 경력 사항</p>
-      </header>
+      <PageHeader title="Education & Experience" description="학력 및 경력 사항" />
 
       <div className="space-y-0">
         {timeline.map((item, index) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,7 +220,7 @@ const contactLinks = [
 
 const SectionHeader = ({ children, href }: { children: React.ReactNode; href?: string }) => {
   const heading = (
-    <h2 className="text-[10px] md:text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground/60">{children}</h2>
+    <h2 className="text-[11px] md:text-xs font-bold uppercase tracking-[0.2em] text-muted-foreground/60">{children}</h2>
   );
   if (href) {
     return (
@@ -242,7 +242,7 @@ const HomePage = () => {
       <motion.section variants={sectionReveal} initial="hidden" animate="visible" className="mb-10 md:mb-16">
         <div className="flex items-center gap-4 md:gap-6">
           <div className="relative shrink-0">
-            <div className="relative w-12 h-12 md:w-16 md:h-16 rounded-full overflow-hidden ring-2 ring-primary-sky/20">
+            <div className="relative w-14 h-14 md:w-16 md:h-16 rounded-full overflow-hidden ring-2 ring-primary-sky/20">
               <Image src="/profile.webp" alt="안성진 프로필" fill className="object-cover" priority />
             </div>
             <div className="absolute -bottom-1 -right-1 w-4 h-4 md:w-5 md:h-5 bg-primary-sky rounded-full border-2 border-background flex items-center justify-center">
@@ -250,7 +250,7 @@ const HomePage = () => {
             </div>
           </div>
           <div className="flex flex-col gap-0.5 md:gap-1">
-            <h1 className="text-xl md:text-2xl font-bold text-foreground tracking-tight">안성진</h1>
+            <h1 className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">안성진</h1>
             <p className="text-xs md:text-sm font-semibold text-muted-foreground">
               Full-Stack Developer, UX Team Lead / Manager
             </p>
@@ -269,7 +269,7 @@ const HomePage = () => {
         viewport={viewportConfig}
         className="mb-10 md:mb-16"
       >
-        <p className="text-sm md:text-base leading-relaxed text-foreground">
+        <p className="text-sm md:text-base leading-relaxed text-foreground min-h-[7rem] sm:min-h-[5.5rem] md:min-h-[5rem]">
           오늘의 쓸모를 다하는 사람,
           <br />
           <TextType
@@ -297,7 +297,7 @@ const HomePage = () => {
         <div className="flex flex-col gap-3 md:gap-4">
           {skillCategories.map((category) => (
             <div key={category.title} className="flex items-start gap-3 md:gap-4">
-              <span className="w-20 md:w-28 pt-1 text-[10px] md:text-xs font-bold text-primary-sky shrink-0 uppercase">
+              <span className="w-20 md:w-28 pt-1 text-[11px] md:text-xs font-bold text-primary-sky shrink-0 uppercase">
                 {category.title}
               </span>
               <div className="flex flex-wrap gap-1.5 md:gap-2">
@@ -328,12 +328,12 @@ const HomePage = () => {
                   index === 0 ? "bg-primary-sky" : "bg-muted-foreground/30"
                 )}
               />
-              <p className="text-[11px] md:text-sm font-bold text-foreground leading-none">
+              <p className="text-xs md:text-sm font-bold text-foreground leading-snug">
                 {item.title} · {item.organization}
               </p>
               <p
                 className={cn(
-                  "text-[10px] md:text-xs mt-1",
+                  "text-[11px] md:text-xs mt-1",
                   index === 0 ? "text-primary-sky" : "text-muted-foreground"
                 )}
               >
@@ -358,7 +358,7 @@ const HomePage = () => {
           initial="hidden"
           whileInView="visible"
           viewport={viewportConfig}
-          className="grid grid-cols-2 gap-2 md:gap-3"
+          className="grid grid-cols-1 sm:grid-cols-2 gap-2 md:gap-3"
         >
           {projects.map((project, index) => (
             <motion.div
@@ -378,10 +378,10 @@ const HomePage = () => {
                   <img src={project.icon} alt="" className="w-8 h-8 md:w-9 md:h-9 rounded-md shrink-0" />
                 )}
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-[11px] md:text-sm font-bold text-foreground group-hover:text-primary-sky transition-colors truncate">
+                  <h3 className="text-sm md:text-base font-bold text-foreground group-hover:text-primary-sky transition-colors truncate">
                     {project.title}
                   </h3>
-                  <p className="text-[9px] md:text-xs text-muted-foreground leading-tight mt-0.5 line-clamp-1">
+                  <p className="text-xs md:text-sm text-muted-foreground leading-snug mt-0.5 line-clamp-1">
                     {project.description}
                   </p>
                 </div>
@@ -389,7 +389,7 @@ const HomePage = () => {
                   {project.tags.slice(0, 3).map((tag) => (
                     <span
                       key={tag}
-                      className="text-[8px] md:text-[10px] px-1 md:px-1.5 py-0.5 bg-background text-muted-foreground rounded-md"
+                      className="text-[10px] md:text-xs px-1.5 py-0.5 bg-background text-muted-foreground rounded-md"
                     >
                       {tag}
                     </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PageContainer } from "@/components/page-container";
-import { TechBadge } from "@/components/skill-badge";
+import { SkillBadge } from "@/components/skill-badge";
 import { TextType } from "@/components/text-type";
 import { sectionReveal, staggerContainer, staggerItem } from "@/lib/animation";
 import type { SkillCategory } from "@/lib/skill-data";
@@ -296,23 +296,13 @@ const HomePage = () => {
         <SectionHeader href="/skills">Technical Stack</SectionHeader>
         <div className="flex flex-col gap-3 md:gap-4">
           {skillCategories.map((category) => (
-            <div key={category.title} className="flex items-center gap-3 md:gap-4">
-              <span className="w-20 md:w-28 text-[10px] md:text-xs font-bold text-primary-sky shrink-0 uppercase">
+            <div key={category.title} className="flex items-start gap-3 md:gap-4">
+              <span className="w-20 md:w-28 pt-1 text-[10px] md:text-xs font-bold text-primary-sky shrink-0 uppercase">
                 {category.title}
               </span>
               <div className="flex flex-wrap gap-1.5 md:gap-2">
                 {category.skills.map((skill) => (
-                  <span
-                    key={skill.name}
-                    className={cn(
-                      "px-2 md:px-3 py-0.5 md:py-1 text-[10px] md:text-xs font-medium rounded",
-                      skill.level === 3 && "bg-primary-sky/20 text-primary-sky font-bold",
-                      skill.level === 2 && "bg-primary-sky/10 text-foreground",
-                      skill.level === 1 && "bg-secondary text-muted-foreground"
-                    )}
-                  >
-                    {skill.name}
-                  </span>
+                  <SkillBadge key={skill.name} skill={skill} />
                 ))}
               </div>
             </div>
@@ -379,13 +369,13 @@ const HomePage = () => {
               <Link
                 href={`/projects/${project.slug}`}
                 className={cn(
-                  "block group p-3 md:p-4 bg-secondary/50 rounded-xl hover:bg-secondary transition-colors",
+                  "block group p-3 md:p-4 bg-secondary/50 rounded-lg hover:bg-accent transition-colors",
                   "flex flex-col gap-2",
                   index === projects.length - 1 && projects.length % 2 !== 0 && "flex-row items-center gap-4"
                 )}
               >
                 {project.icon && (
-                  <img src={project.icon} alt="" className="w-8 h-8 md:w-9 md:h-9 rounded-lg shrink-0" />
+                  <img src={project.icon} alt="" className="w-8 h-8 md:w-9 md:h-9 rounded-md shrink-0" />
                 )}
                 <div className="flex-1 min-w-0">
                   <h3 className="text-[11px] md:text-sm font-bold text-foreground group-hover:text-primary-sky transition-colors truncate">
@@ -399,7 +389,7 @@ const HomePage = () => {
                   {project.tags.slice(0, 3).map((tag) => (
                     <span
                       key={tag}
-                      className="text-[8px] md:text-[10px] px-1 md:px-1.5 py-0.5 bg-background text-muted-foreground rounded"
+                      className="text-[8px] md:text-[10px] px-1 md:px-1.5 py-0.5 bg-background text-muted-foreground rounded-md"
                     >
                       {tag}
                     </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { TextType } from "@/components/text-type";
 import { sectionReveal, staggerContainer, staggerItem } from "@/lib/animation";
 import type { SkillCategory } from "@/lib/skill-data";
 import { cn } from "@/lib/utils";
-import { ArrowUpRight, Code, Database, Server, Wrench } from "lucide-react";
+import { ArrowUpRight, Code } from "lucide-react";
 import { motion } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -26,7 +26,6 @@ const aboutPhrases = [
 const skillCategories: SkillCategory[] = [
   {
     title: "Frontend",
-    icon: <Code className="w-5 h-5" />,
     skills: [
       { name: "Next.js", level: 3 },
       { name: "React", level: 3 },
@@ -37,7 +36,6 @@ const skillCategories: SkillCategory[] = [
   },
   {
     title: "Backend",
-    icon: <Server className="w-5 h-5" />,
     skills: [
       { name: "Prisma", level: 3 },
       { name: "Java", level: 2 },
@@ -50,7 +48,6 @@ const skillCategories: SkillCategory[] = [
   },
   {
     title: "DevOps & Tools",
-    icon: <Wrench className="w-5 h-5" />,
     skills: [
       { name: "AWS (EC2, S3)", level: 2 },
       { name: "Caddy", level: 2 },
@@ -63,7 +60,6 @@ const skillCategories: SkillCategory[] = [
   },
   {
     title: "Android",
-    icon: <Database className="w-5 h-5" />,
     skills: [
       { name: "Kotlin", level: 1 },
       { name: "Jetpack Compose", level: 1 },

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getAllPosts, getPostBySlug } from "@/_posts";
 import { PostItems } from "@/app/posts/post-items";
 import { GiscusComments } from "@/components/giscus-comments";
 import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { Pagination } from "@/components/pagination";
 import { TableOfContents } from "@/components/table-of-contents";
 import { Badge } from "@/components/ui/badge";
@@ -81,10 +82,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
     return (
       <PageContainer>
-        <header className="mb-10">
-          <h1 className="text-xl font-semibold text-foreground tracking-tight">Posts</h1>
-          <p className="text-sm text-muted-foreground mt-1">기술 블로그 포스트</p>
-        </header>
+        <PageHeader title="Posts" description="기술 블로그 포스트" />
 
         <PostItems posts={paged} />
         <Pagination currentPage={page} totalPages={totalPages} basePath="/posts" />

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,6 +1,7 @@
 import { getAllPosts } from "@/_posts";
 import { PostItems } from "@/app/posts/post-items";
 import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { Pagination } from "@/components/pagination";
 
 const PAGE_SIZE = 10;
@@ -12,10 +13,7 @@ export default async function PostsPage() {
 
   return (
     <PageContainer>
-      <header className="mb-10">
-        <h1 className="text-xl font-semibold text-foreground tracking-tight">Posts</h1>
-        <p className="text-sm text-muted-foreground mt-1">기술 블로그 포스트</p>
-      </header>
+      <PageHeader title="Posts" description="기술 블로그 포스트" />
 
       <PostItems posts={paged} />
       <Pagination currentPage={1} totalPages={totalPages} basePath="/posts" />

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -1,4 +1,5 @@
 import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { SkillBadge } from "@/components/skill-badge";
 import type { SkillCategory } from "@/lib/skill-data";
 
@@ -59,10 +60,7 @@ const skillCategories: SkillCategory[] = [
 const SkillsPage = () => {
   return (
     <PageContainer>
-      <header className="mb-10">
-        <h1 className="text-xl font-semibold text-foreground tracking-tight">Skills</h1>
-        <p className="text-sm text-muted-foreground mt-1">기술 스택 및 역량</p>
-      </header>
+      <PageHeader title="Skills" description="기술 스택 및 역량" />
 
       <div className="space-y-4">
         {skillCategories.map((category) => (

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -10,7 +10,7 @@ export const Footer = () => {
   return (
     <footer className="border-t border-border">
       <div className="max-w-4xl mx-auto px-6 sm:px-8 md:px-12 lg:px-16 py-6 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-muted-foreground">
-        <span>© 2025 anveloper.dev</span>
+        <span>© {new Date().getFullYear()} anveloper.dev</span>
         <nav aria-label="푸터 링크" className="flex items-center gap-3">
           {links.map((link, i) => (
             <span key={link.label} className="flex items-center gap-3">

--- a/components/page-header.tsx
+++ b/components/page-header.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+type PageHeaderProps = {
+  title: string;
+  description?: string;
+  /** 헤더 우측에 배치할 액션 영역 (필터 버튼 등) */
+  action?: React.ReactNode;
+  className?: string;
+};
+
+/** 내부 페이지 공용 헤더 — 페이지 타이틀 + 서브타이틀 단일 소스 */
+export const PageHeader = ({ title, description, action, className }: PageHeaderProps) => {
+  return (
+    <header className={cn("mb-10 flex items-start justify-between gap-4", className)}>
+      <div>
+        <h1 className="text-xl font-semibold text-foreground tracking-tight">{title}</h1>
+        {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+      </div>
+      {action}
+    </header>
+  );
+};

--- a/components/project-list.tsx
+++ b/components/project-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/page-header";
 import { TechBadge } from "@/components/skill-badge";
 import { FolderKanban, ListFilter, X } from "lucide-react";
 
@@ -30,40 +31,40 @@ export const ProjectList = ({ projects }: { projects: Project[] }) => {
 
   return (
     <>
-      <header className="flex items-center justify-between mb-10">
-        <div>
-          <h1 className="text-xl font-semibold text-foreground tracking-tight">Projects</h1>
-          <p className="text-sm text-muted-foreground mt-1">프로젝트 포트폴리오</p>
-        </div>
-        {allTags.length > 0 && (
-          <div className="flex items-center gap-1.5">
-            {selectedTags.length > 0 && (
+      <PageHeader
+        title="Projects"
+        description="프로젝트 포트폴리오"
+        action={
+          allTags.length > 0 && (
+            <div className="flex items-center gap-1.5 shrink-0">
+              {selectedTags.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedTags([])}
+                  aria-label="필터 초기화"
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
               <button
                 type="button"
-                onClick={() => setSelectedTags([])}
-                aria-label="필터 초기화"
-                className="w-8 h-8 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+                onClick={() => setShowFilter((v) => !v)}
+                aria-label={showFilter ? "필터 닫기" : "필터 열기"}
+                aria-expanded={showFilter}
+                className="relative w-8 h-8 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
               >
-                <X className="w-4 h-4" />
+                <ListFilter className="w-4 h-4" />
+                {selectedTags.length > 0 && (
+                  <span className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center">
+                    {selectedTags.length}
+                  </span>
+                )}
               </button>
-            )}
-            <button
-              type="button"
-              onClick={() => setShowFilter((v) => !v)}
-              aria-label={showFilter ? "필터 닫기" : "필터 열기"}
-              aria-expanded={showFilter}
-              className="relative w-8 h-8 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
-            >
-              <ListFilter className="w-4 h-4" />
-              {selectedTags.length > 0 && (
-                <span className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[10px] flex items-center justify-center">
-                  {selectedTags.length}
-                </span>
-              )}
-            </button>
-          </div>
-        )}
-      </header>
+            </div>
+          )
+        }
+      />
 
       {showFilter && allTags.length > 0 && (
         <div role="group" aria-label="기술 태그 필터" className="flex flex-wrap gap-1.5 mb-8">
@@ -87,35 +88,39 @@ export const ProjectList = ({ projects }: { projects: Project[] }) => {
           </p>
         </div>
       ) : (
-        <div className="divide-y divide-border">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {filtered.map((project) => (
-            <Link key={project.slug} href={`/projects/${project.slug}`} className="block group">
-              <div className="py-6">
-                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 mb-2">
+            <Link
+              key={project.slug}
+              href={`/projects/${project.slug}`}
+              className="group flex flex-col gap-3 p-4 bg-secondary/50 rounded-lg hover:bg-accent transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                {project.icon && <img src={project.icon} alt="" className="w-10 h-10 rounded-md shrink-0" />}
+                <div className="min-w-0 flex-1">
+                  <h2 className="text-base font-medium text-foreground group-hover:text-primary-sky transition-colors truncate">
+                    {project.frontmatter.title as string}
+                  </h2>
                   <time
                     dateTime={(project.frontmatter.date as string).replace(/\./g, "-")}
-                    className="text-sm text-muted-foreground shrink-0"
+                    className="text-xs text-muted-foreground"
                   >
                     {project.frontmatter.date as string}
                   </time>
-                  <div className="flex items-center gap-2">
-                    {project.icon && <img src={project.icon} alt="" className="w-6 h-6 rounded" />}
-                    <h2 className="text-lg font-medium text-foreground group-hover:text-primary-sky transition-colors">
-                      {project.frontmatter.title as string}
-                    </h2>
-                  </div>
                 </div>
-                {typeof project.frontmatter.description === "string" && (
-                  <p className="text-muted-foreground mb-3 sm:ml-24">{project.frontmatter.description}</p>
-                )}
-                {Array.isArray(project.frontmatter.tags) && (
-                  <div className="flex flex-wrap gap-1 sm:ml-24">
-                    {(project.frontmatter.tags as string[]).slice(0, 5).map((tag) => (
-                      <TechBadge key={tag} name={tag} />
-                    ))}
-                  </div>
-                )}
               </div>
+              {typeof project.frontmatter.description === "string" && (
+                <p className="text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                  {project.frontmatter.description}
+                </p>
+              )}
+              {Array.isArray(project.frontmatter.tags) && (
+                <div className="flex flex-wrap gap-1 mt-auto">
+                  {(project.frontmatter.tags as string[]).slice(0, 5).map((tag) => (
+                    <TechBadge key={tag} name={tag} />
+                  ))}
+                </div>
+              )}
             </Link>
           ))}
         </div>

--- a/components/theme-selector.tsx
+++ b/components/theme-selector.tsx
@@ -146,8 +146,9 @@ export const ThemeSelector = () => {
           aria-label="테마 목록"
           aria-activedescendant={focusedIndex >= 0 ? `theme-option-${themeOptions[focusedIndex].value}` : undefined}
           className={cn(
-            "absolute right-1/2 translate-x-1/2 top-full mt-1 z-50",
+            "absolute right-1/2 translate-x-1/2 top-full mt-2 z-50",
             "flex flex-col items-center gap-1.5 p-2",
+            "bg-popover/95 backdrop-blur-sm border border-border rounded-lg shadow-lg",
             "animate-in fade-in-0 zoom-in-95"
           )}
         >

--- a/docs/design/20260620-design-consistency-plan.md
+++ b/docs/design/20260620-design-consistency-plan.md
@@ -1,0 +1,117 @@
+# 디자인 일관성·가독성 보완 계획
+
+> 작성일: 2026-06-20
+> 목적: 2026-02-16 리뉴얼 이후 누적된 디자인 시스템 불일치와 가독성 문제 보완
+> 범위: 기능 유지, 디자인(레이아웃/타이포그래피/토큰/색상)만 수정
+> 선행: [20260216-design-revision-plan.md](./20260216-design-revision-plan.md) (텍스트 중심 미니멀 전환 완료)
+
+---
+
+## 1. 현황 진단
+
+2026-02-16 리뉴얼로 "AI 템플릿" 느낌은 해소되고 텍스트 중심 미니멀 톤으로 통일되었으나,
+이후 콘텐츠/페이지가 늘어나면서 **디자인 시스템 일관성**과 **타이포그래피 가독성**에 균열이 생김.
+
+### 1.1 강점 (유지)
+
+- 4가지 테마(light/dark/korean/terminal) — 차별화된 정체성
+- 단일 컬럼 `max-w-4xl` 미니멀 레이아웃
+- 탄탄한 접근성 기반 (skip-nav, focus-visible, reduced-motion, forced-colors, prefers-contrast)
+- 일관된 `muted-foreground` 위계
+
+### 1.2 보완 지점
+
+| 우선순위 | 항목 | 해당 파일 |
+| -------- | ---- | --------- |
+| **P1** | 페이지 헤더 시스템 이중화 (홈 마이크로라벨 vs 내부 h1) | `app/page.tsx:221`, 전 내부 페이지 |
+| **P1** | 프로젝트 표현 불일치 (홈 카드 vs /projects 텍스트 리스트) | `app/page.tsx:357`, `components/project-list.tsx:90` |
+| **P1** | 기술 스택 시각화 이중화 (홈 level 그라데이션 vs /skills shields 뱃지) | `app/page.tsx:305`, `app/skills/page.tsx:75` |
+| **P1** | radius/surface/hover 토큰 혼용 | 전역 |
+| **P2** | 홈 텍스트 과소 사이즈 (`text-[8px]`~`text-[11px]`) | `app/page.tsx:223,300,394,402` |
+| **P2** | 모바일 카드 그리드 2열 강제 | `app/page.tsx:371` |
+| **P2** | Hero focal point 약함 | `app/page.tsx:242` |
+| **P2** | TextType 레이아웃 시프트 위험 | `app/page.tsx:275` |
+| **P3** | 푸터 연도 하드코딩 (`© 2025`) | `components/footer.tsx:13` |
+| **P3** | 색상 단조 (chart 토큰 미사용) | 전역 |
+| **P3** | 테마 셀렉터 팝오버 anchor 약함 | `components/theme-selector.tsx:143` |
+| **P3** | prose + mdx 커스텀 오버라이드 중복 | `app/posts/[slug]`, `lib/mdx-components.ts` |
+| **P3** | Contact 중복 (홈 Connect vs /contact) | `app/page.tsx:414`, `app/contact/page.tsx` |
+
+---
+
+## 2. 디자인 방향성
+
+기존 리뉴얼의 "텍스트 중심 미니멀 + 에디토리얼" 방향을 유지하되, **토큰화·체계화**로 일관성을 확보한다.
+
+1. **단일 헤더 시스템** — 페이지 헤더 패턴을 하나로 통일
+2. **단일 표현 언어** — 같은 데이터(프로젝트/스킬)는 어디서나 같은 시각 언어
+3. **토큰 규칙화** — radius/surface/hover를 역할별로 고정
+4. **가독성 하한 준수** — 본문 ≥ 12px, 라벨 ≥ 11px
+5. **모바일 우선 검증** — 1열 → 2열 점진 확장
+
+---
+
+## 3. 단계별 작업 계획
+
+### Phase 1: 토큰·기반 정리 (P1-4, P3 일부) ✅
+
+> 참고: 이 테마에서 `secondary`/`muted`/`accent`는 동일 색상값이라 hover 차이는 시각이 아닌 코드 일관성 문제.
+
+- [x] radius 규칙 확정: 표면(카드/링크박스/썸네일/테이블) `rounded-lg`(=`--radius`), 뱃지/태그/아이콘/버튼 `rounded-md`, 원형 `rounded-full`
+- [x] hover 배경 규칙 확정: 표면 hover는 `hover:bg-accent`로 통일 (홈 프로젝트 카드 `hover:bg-secondary`→`hover:bg-accent`)
+- [x] 푸터 연도 동적 처리 (`new Date().getFullYear()`)
+- [x] 적용: 홈 스킬칩/태그/아이콘 `rounded`/`rounded-xl`→규칙화, project-list 아이콘 `rounded`→`rounded-md`
+
+### Phase 2: 헤더 시스템 통일 (P1-1) ✅
+
+> 진단 결과: 내부 페이지 헤더 스타일은 이미 동일하나 6개 파일에 중복 작성됨. 단일 소스화로 drift 방지.
+> 홈 `SectionHeader`(마이크로 라벨)는 "섹션 구분"용으로 역할이 다르므로 유지 — 페이지 타이틀과 구분.
+
+- [x] 공용 `components/page-header.tsx` 추출 (title/description/action 슬롯)
+- [x] posts/contact/about/skills/education + project-list + posts/[slug] 페이지네이션 뷰 전부 적용
+- [x] project-list 필터 버튼은 `action` 슬롯으로 이전, hover `bg-muted`→`bg-accent` 정리
+
+### Phase 3: 표현 언어 통일 (P1-2, P1-3) ✅
+
+- [x] `/projects` 리스트(divide-y 텍스트) → 아이콘 카드 그리드(`grid-cols-1 sm:grid-cols-2`)로 전환, 홈과 결 맞춤
+- [x] 스킬 시각화 단일화: **shields 뱃지로 통일** (사용자 결정) — 홈 그라데이션 칩 → `SkillBadge`(shields + 🔥)
+
+### Phase 4: 타이포그래피·반응형 (P2)
+
+- [ ] 홈 초소형 텍스트 상향 (본문 ≥ 12px, 라벨 ≥ 11px)
+- [ ] 홈 Featured Projects 그리드 `grid-cols-1 sm:grid-cols-2`
+- [ ] Hero focal point 강화 (이름/태그라인 사이즈 검토)
+- [ ] TextType 컨테이너 `min-h` 예약으로 레이아웃 시프트 방지
+
+### Phase 5: 디테일·마무리 (P3)
+
+- [ ] 색상: chart 토큰 활용 또는 카테고리별 미세 액센트 (의도적 미니멀 유지 시 보류)
+- [ ] 테마 셀렉터 팝오버 패널 배경/보더 추가
+- [ ] prose vs mdx 오버라이드 정리 (중복 제거)
+- [ ] Contact 중복 역할 정리 (홈 Connect / /contact 구분 또는 통합)
+
+### Phase 6: 검증
+
+- [ ] `pnpm build` 성공
+- [ ] `pnpm lint` 성공
+- [ ] 4개 테마 × sm~xl 반응형 시각 확인
+- [ ] 콘솔 에러 없음
+
+---
+
+## 4. 수정하지 않는 것
+
+- 네비게이션 구조 및 라우팅
+- MDX 콘텐츠 렌더링 파이프라인
+- 4개 테마 체계 자체
+- SEO 메타데이터
+- 정적 빌드 호환성 (GitHub Pages)
+- 콘텐츠 데이터 자체
+
+---
+
+## 5. 변경 이력
+
+| 날짜 | 내용 |
+| ---- | ---- |
+| 2026-06-20 | 초안 작성 — 일관성/가독성 보완 6단계 계획 수립 |

--- a/docs/design/20260620-design-consistency-plan.md
+++ b/docs/design/20260620-design-consistency-plan.md
@@ -83,19 +83,20 @@
 - [x] Hero focal point 강화: 이름 `text-xl md:text-2xl`→`text-2xl md:text-3xl`, 아바타 모바일 `w-14`
 - [x] TextType 컨테이너 `min-h-[7rem] sm:min-h-[5.5rem] md:min-h-[5rem]` 예약으로 레이아웃 시프트 방지
 
-### Phase 5: 디테일·마무리 (P3)
+### Phase 5: 디테일·마무리 (P3) ✅
 
-- [ ] 색상: chart 토큰 활용 또는 카테고리별 미세 액센트 (의도적 미니멀 유지 시 보류)
-- [ ] 테마 셀렉터 팝오버 패널 배경/보더 추가
-- [ ] prose vs mdx 오버라이드 정리 (중복 제거)
-- [ ] Contact 중복 역할 정리 (홈 Connect / /contact 구분 또는 통합)
+- [x] 테마 셀렉터 팝오버 패널 배경/보더 추가 (`bg-popover/95 backdrop-blur-sm border rounded-lg shadow-lg`)
+- [x] 색상: **보류** — 4개 테마 + 미니멀 정체성 보존 우선. chart 토큰 도입 시 테마별 충돌 위험
+- [x] prose vs mdx: **유지** — prose는 mdx-components 미적용 요소(h5/h6 등)의 fallback, 실제 시각 충돌 없음
+- [x] Contact 중복: **유지** — 홈 Connect(요약 teaser) / /contact(전용 페이지)는 포트폴리오 표준 패턴
 
-### Phase 6: 검증
+### Phase 6: 검증 ✅
 
-- [ ] `pnpm build` 성공
-- [ ] `pnpm lint` 성공
-- [ ] 4개 테마 × sm~xl 반응형 시각 확인
-- [ ] 콘솔 에러 없음
+- [x] `pnpm build` 성공 (43/43 정적 페이지)
+- [x] `pnpm lint` 성공 (0 errors)
+- [x] 미사용 코드 정리: 홈 skillCategories `icon` 필드 + lucide(Server/Wrench/Database) import 제거
+- [ ] 4개 테마 × sm~xl 반응형 시각 확인 — 개발 서버 확인 필요
+- [ ] 콘솔 에러 없음 — 브라우저 확인 필요
 
 ---
 
@@ -115,3 +116,4 @@
 | 날짜 | 내용 |
 | ---- | ---- |
 | 2026-06-20 | 초안 작성 — 일관성/가독성 보완 6단계 계획 수립 |
+| 2026-06-20 | Phase 1-6 완료 — 토큰 규칙화, PageHeader 추출, /projects 카드화, 스킬 shields 통일, 홈 가독성·반응형, 테마 셀렉터 패널, 미사용 코드 정리 |

--- a/docs/design/20260620-design-consistency-plan.md
+++ b/docs/design/20260620-design-consistency-plan.md
@@ -76,12 +76,12 @@
 - [x] `/projects` 리스트(divide-y 텍스트) → 아이콘 카드 그리드(`grid-cols-1 sm:grid-cols-2`)로 전환, 홈과 결 맞춤
 - [x] 스킬 시각화 단일화: **shields 뱃지로 통일** (사용자 결정) — 홈 그라데이션 칩 → `SkillBadge`(shields + 🔥)
 
-### Phase 4: 타이포그래피·반응형 (P2)
+### Phase 4: 타이포그래피·반응형 (P2) ✅
 
-- [ ] 홈 초소형 텍스트 상향 (본문 ≥ 12px, 라벨 ≥ 11px)
-- [ ] 홈 Featured Projects 그리드 `grid-cols-1 sm:grid-cols-2`
-- [ ] Hero focal point 강화 (이름/태그라인 사이즈 검토)
-- [ ] TextType 컨테이너 `min-h` 예약으로 레이아웃 시프트 방지
+- [x] 홈 초소형 텍스트 상향: 라벨 10px→11px, 카드 제목 `text-sm md:text-base`, 설명/태그 상향, Milestones 11px↑
+- [x] 홈 Featured Projects 그리드 `grid-cols-2`→`grid-cols-1 sm:grid-cols-2`
+- [x] Hero focal point 강화: 이름 `text-xl md:text-2xl`→`text-2xl md:text-3xl`, 아바타 모바일 `w-14`
+- [x] TextType 컨테이너 `min-h-[7rem] sm:min-h-[5.5rem] md:min-h-[5rem]` 예약으로 레이아웃 시프트 방지
 
 ### Phase 5: 디테일·마무리 (P3)
 


### PR DESCRIPTION
## Summary

- 디자인 시스템 일관성·가독성 보완 (2026-02-16 리뉴얼 후속)
- 계획 문서: `docs/design/20260620-design-consistency-plan.md`

## Changes

### 기능

- 공용 `PageHeader` 컴포넌트 추출 → 내부 7개 페이지 적용 (헤더 중복 제거)
- `/projects` 목록을 텍스트 리스트 → 카드 그리드로 전환 (홈과 표현 통일)
- 스킬 시각화를 shields 뱃지로 단일화 (홈 그라데이션 칩 제거)

### 스타일

- radius 토큰 규칙화 (표면 `rounded-lg` / 뱃지 `rounded-md` / 원형 `rounded-full`), hover `bg-accent` 통일
- 홈 타이포그래피 가독성 상향 (초소형 8~10px → 11px↑), Featured Projects 모바일 1열
- Hero 이름 크기 확대, TextType `min-h` 예약으로 레이아웃 시프트 방지
- 테마 셀렉터 팝오버 패널 배경·보더 추가

### 기타

- 푸터 저작권 연도 동적 처리
- 홈 미사용 스킬 아이콘 데이터·import 제거

## Test plan

- [x] `pnpm build` 성공 (43/43 정적 페이지)
- [x] `pnpm lint` 성공 (0 errors)
- [ ] 4개 테마 × sm~xl 반응형 시각 확인 (특히 묵향·터미널 테마의 shields 뱃지)
- [ ] 주요 페이지 렌더링 확인

## Notes

- 색상 다양화 / prose 정리 / Contact 통합은 근거와 함께 보류·유지 결정 (계획 문서 Phase 5 참고)
